### PR TITLE
Fix typo in Container.svelte: 'PointLiek' -> 'PointLike'

### DIFF
--- a/src/lib/Container.svelte
+++ b/src/lib/Container.svelte
@@ -338,7 +338,7 @@
   /**
    * The skew factor for the object in radians.
    *
-   * @type {PointLiek}
+   * @type {PointLike}
    */
   export let skew: $$Props['skew'] = undefined
 


### PR DESCRIPTION
👋  just the smallest possible fix :)