### PR TITLE
Export component props

### DIFF
--- a/.changeset/spotty-shirts-train.md
+++ b/.changeset/spotty-shirts-train.md
@@ -1,0 +1,5 @@
+---
+'svelte-pixi': patch
+---
+
+export each component's `…Props` type

--- a/.changeset/spotty-shirts-train.md
+++ b/.changeset/spotty-shirts-train.md
@@ -3,3 +3,4 @@
 ---
 
 export each component's `…Props` type
+export `createApplyProps`, `applyProps`, `applyProp` utility functions and corresponding `Apply` type

--- a/src/lib/svelte-5/index.ts
+++ b/src/lib/svelte-5/index.ts
@@ -51,3 +51,9 @@ export {
 export { getRenderer } from '../core/context/renderer'
 export { getTicker, onTick, track, tick } from '../core/context/ticker'
 export { asset, texture } from '../core/util/asset'
+export {
+  createApplyProps,
+  applyProps,
+  applyProp,
+  type Apply,
+} from '../core/util/props'

--- a/src/lib/svelte-5/index.ts
+++ b/src/lib/svelte-5/index.ts
@@ -1,21 +1,45 @@
-export { default as AnimatedSprite } from './AnimatedSprite.svelte'
-export { default as Application } from './Application.svelte'
-export { default as AssetsLoader } from './AssetsLoader.svelte'
-export { default as BitmapText } from './BitmapText.svelte'
-export { default as Container } from './Container.svelte'
-export { default as Graphics } from './Graphics.svelte'
-export { default as HTMLText } from './HTMLText.svelte'
-export { default as Mesh } from './Mesh.svelte'
-export { default as MeshPlane } from './MeshPlane.svelte'
-export { default as MeshRope } from './MeshRope.svelte'
-export { default as NineSliceSprite } from './NineSliceSprite.svelte'
-export { default as ParticleContainer } from './ParticleContainer.svelte'
-export { default as PerspectiveMesh } from './PerspectiveMesh.svelte'
-export { default as Ticker } from './Ticker.svelte'
-export { default as TilingSprite } from './TilingSprite.svelte'
-export { default as Text } from './Text.svelte'
-export { default as Sprite } from './Sprite.svelte'
-export { default as Renderer } from './Renderer.svelte'
+export {
+  default as AnimatedSprite,
+  type AnimatedSpriteProps,
+} from './AnimatedSprite.svelte'
+export {
+  default as Application,
+  type ApplicationProps,
+} from './Application.svelte'
+export {
+  default as AssetsLoader,
+  type AssetsLoaderProps,
+} from './AssetsLoader.svelte'
+export {
+  default as BitmapText,
+  type BitmapTextProps,
+} from './BitmapText.svelte'
+export { default as Container, type ContainerProps } from './Container.svelte'
+export { default as Graphics, type GraphicsProps } from './Graphics.svelte'
+export { default as HTMLText, type HTMLTextProps } from './HTMLText.svelte'
+export { default as Mesh, type MeshProps } from './Mesh.svelte'
+export { default as MeshPlane, type MeshPlaneProps } from './MeshPlane.svelte'
+export { default as MeshRope, type MeshRopeProps } from './MeshRope.svelte'
+export {
+  default as NineSliceSprite,
+  type NineSliceSpriteProps,
+} from './NineSliceSprite.svelte'
+export {
+  default as ParticleContainer,
+  type ParticleContainerProps,
+} from './ParticleContainer.svelte'
+export {
+  default as PerspectiveMesh,
+  type PerspectiveMeshProps,
+} from './PerspectiveMesh.svelte'
+export { default as Ticker, type TickerProps } from './Ticker.svelte'
+export {
+  default as TilingSprite,
+  type TilingSpriteProps,
+} from './TilingSprite.svelte'
+export { default as Text, type TextProps } from './Text.svelte'
+export { default as Sprite, type SpriteProps } from './Sprite.svelte'
+export { default as Renderer, type RendererProps } from './Renderer.svelte'
 
 export { getApp } from '../core/context/app'
 export {


### PR DESCRIPTION
This exports the components' corresponding props types, that that you can properly refer to them in downstream code.

Further more it exports `createApplyProps`, `applyProps`, `applyProp`, `type Apply`, allowing for defining one's own PIXI wrapper types (e.g. for `Viewport` from `pixi-viewport`).