### PR TITLE
Document type-safety limitation (violation of liskov substution principle)

### DIFF
--- a/.changeset/tricky-seas-burn.md
+++ b/.changeset/tricky-seas-burn.md
@@ -1,0 +1,5 @@
+---
+'svelte-pixi': patch
+---
+
+document type-limitations related to default-initialization of sub-typed PIXI instances

--- a/docs/src/content/docs/api/components/animated-sprite.mdx
+++ b/docs/src/content/docs/api/components/animated-sprite.mdx
@@ -15,6 +15,27 @@ I recommend using spritesheets created by TexturePacker ([they have a great tuto
   source="https://pixijs.download/dev/docs/scene.AnimatedSprite.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.AnimatedSprite` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.AnimatedSprite` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyAnimatedSprite extends PIXI.AnimatedSprite {
+  myCustomMethod() { ... }
+}
+
+const sprite = new MyAnimatedSprite(textures)
+<AnimatedSprite instance={sprite} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.AnimatedSprite` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 ### Basic

--- a/docs/src/content/docs/api/components/application.mdx
+++ b/docs/src/content/docs/api/components/application.mdx
@@ -13,6 +13,44 @@ Just like `PIXI.Application`, it sets up the [Renderer](/docs/components/rendere
   source="https://pixijs.download/dev/docs/app.Application.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Application` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.Application`
+will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access
+subclass-specific properties or methods that don't actually exist on the instance.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyApp extends PIXI.Application {
+  myCustomMethod() { ... }
+}
+
+// Create your instance first
+const app = new MyApp()
+
+// Then pass it to the component
+<Application instance={app} />
+```
+
+**Incorrect Usage (will cause runtime errors):**
+
+```typescript
+// DON'T DO THIS with subclasses
+let app: MyApp  // Type says MyApp, but actual instance will be PIXI.Application
+<Application bind:instance={app} />
+
+// This will fail at runtime:
+app.myCustomMethod()  // Error: myCustomMethod is not a function
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49) and is a known tradeoff of the current API design.
+When using the base `PIXI.Application` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/bitmap-text.mdx
+++ b/docs/src/content/docs/api/components/bitmap-text.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.BitmapText. Bitmap fonts **must** be loaded before use.
   source="https://pixijs.download/dev/docs/scene.BitmapText.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.BitmapText` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.BitmapText` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyBitmapText extends PIXI.BitmapText {
+  myCustomMethod() { ... }
+}
+
+const bitmapText = new MyBitmapText()
+<BitmapText instance={bitmapText} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.BitmapText` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/container.mdx
+++ b/docs/src/content/docs/api/components/container.mdx
@@ -15,6 +15,30 @@ When child components are rendered inside, their coordinates become local to the
   source="https://pixijs.download/dev/docs/scene.Container.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Container` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.Container`
+will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access
+subclass-specific properties or methods that don't actually exist on the instance.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyContainer extends PIXI.Container {
+  myCustomMethod() { ... }
+}
+
+const container = new MyContainer()
+<Container instance={container} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49).
+When using the base `PIXI.Container` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 ### Basic

--- a/docs/src/content/docs/api/components/graphics.mdx
+++ b/docs/src/content/docs/api/components/graphics.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.Graphics. Use the `draw` prop to interact with the Graphics API.
   source="https://pixijs.download/dev/docs/scene.Graphics.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Graphics` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.Graphics` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyGraphics extends PIXI.Graphics {
+  myCustomMethod() { ... }
+}
+
+const graphics = new MyGraphics()
+<Graphics instance={graphics} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.Graphics` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 ### Draw prop

--- a/docs/src/content/docs/api/components/html-text.mdx
+++ b/docs/src/content/docs/api/components/html-text.mdx
@@ -15,6 +15,27 @@ Renders text with support for styling via HTML tags. The rendering can vary acro
   source="https://pixijs.download/dev/docs/scene.HTMLText.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.HTMLText` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.HTMLText` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyHTMLText extends PIXI.HTMLText {
+  myCustomMethod() { ... }
+}
+
+const htmlText = new MyHTMLText()
+<HTMLText instance={htmlText} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.HTMLText` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/mesh-plane.mdx
+++ b/docs/src/content/docs/api/components/mesh-plane.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.MeshPlane.
   source="https://pixijs.download/dev/docs/scene.MeshPlane.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.MeshPlane` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.MeshPlane` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyMeshPlane extends PIXI.MeshPlane {
+  myCustomMethod() { ... }
+}
+
+const plane = new MyMeshPlane(texture)
+<MeshPlane instance={plane} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.MeshPlane` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/mesh-rope.mdx
+++ b/docs/src/content/docs/api/components/mesh-rope.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.MeshRope.
   source="https://pixijs.download/dev/docs/scene.MeshRope.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.MeshRope` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.MeshRope` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyMeshRope extends PIXI.MeshRope {
+  myCustomMethod() { ... }
+}
+
+const rope = new MyMeshRope(texture, points)
+<MeshRope instance={rope} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.MeshRope` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/mesh.mdx
+++ b/docs/src/content/docs/api/components/mesh.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.Mesh.
   source="https://pixijs.download/dev/docs/scene.Mesh.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Mesh` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.Mesh` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyMesh extends PIXI.Mesh {
+  myCustomMethod() { ... }
+}
+
+const mesh = new MyMesh(geometry, shader)
+<Mesh instance={mesh} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.Mesh` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/nine-slice-sprite.mdx
+++ b/docs/src/content/docs/api/components/nine-slice-sprite.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.NineSliceSprite.
   source="https://pixijs.download/dev/docs/scene.NineSliceSprite.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.NineSliceSprite` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.NineSliceSprite` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyNineSliceSprite extends PIXI.NineSliceSprite {
+  myCustomMethod() { ... }
+}
+
+const sprite = new MyNineSliceSprite(texture)
+<NineSliceSprite instance={sprite} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.NineSliceSprite` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/particle-container.mdx
+++ b/docs/src/content/docs/api/components/particle-container.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.ParticleContainer.
   source="https://pixijs.download/dev/docs/scene.ParticleContainer.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.ParticleContainer` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.ParticleContainer` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyParticleContainer extends PIXI.ParticleContainer {
+  myCustomMethod() { ... }
+}
+
+const container = new MyParticleContainer()
+<ParticleContainer instance={container} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.ParticleContainer` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 Note: when working with thousands of components, it is **much** more performant to create & update the Pixi instances directly instead of through components

--- a/docs/src/content/docs/api/components/perspective-mesh.mdx
+++ b/docs/src/content/docs/api/components/perspective-mesh.mdx
@@ -15,6 +15,27 @@ Renders a PIXI.PerspectiveMesh.
   source="https://pixijs.download/dev/docs/scene.PerspectiveMesh.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.PerspectiveMesh` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.PerspectiveMesh` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyPerspectiveMesh extends PIXI.PerspectiveMesh {
+  myCustomMethod() { ... }
+}
+
+const mesh = new MyPerspectiveMesh(texture)
+<PerspectiveMesh instance={mesh} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.PerspectiveMesh` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/renderer.mdx
+++ b/docs/src/content/docs/api/components/renderer.mdx
@@ -12,6 +12,30 @@ start the render loop or create the root container for you. You will need to do 
 By default it will call `PIXI.autoDetectRenderer` to determine the `instance`. Like Application, this
 is an asynchronous operation and will call `oninit` when complete.
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Renderer` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you rely on `autoDetectRenderer()` without providing an instance,
+the result will be unsafely cast to your subclass type. This will cause **runtime errors** when trying to access
+subclass-specific properties or methods that don't actually exist on the instance.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyRenderer extends PIXI.Renderer {
+  myCustomMethod() { ... }
+}
+
+const renderer = new MyRenderer()
+<Renderer instance={renderer} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49).
+When using the base `PIXI.Renderer` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 ### Basic

--- a/docs/src/content/docs/api/components/sprite.mdx
+++ b/docs/src/content/docs/api/components/sprite.mdx
@@ -15,6 +15,27 @@ Textures **must** be loaded before use either with [AssetsLoader](/api/component
   source="https://pixijs.download/dev/docs/scene.Sprite.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Sprite` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.Sprite` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MySprite extends PIXI.Sprite {
+  myCustomMethod() { ... }
+}
+
+const sprite = new MySprite()
+<Sprite instance={sprite} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.Sprite` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/text.mdx
+++ b/docs/src/content/docs/api/components/text.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.Text.
   source="https://pixijs.download/dev/docs/scene.Text.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Text` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.Text` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyText extends PIXI.Text {
+  myCustomMethod() { ... }
+}
+
+const text = new MyText()
+<Text instance={text} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.Text` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 ### Basic

--- a/docs/src/content/docs/api/components/ticker.mdx
+++ b/docs/src/content/docs/api/components/ticker.mdx
@@ -13,6 +13,30 @@ Children of this component can use [onTick](/docs/utilities/on-tick) to hook int
   source="https://pixijs.download/dev/docs/app.Ticker.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.Ticker` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.Ticker`
+will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access
+subclass-specific properties or methods that don't actually exist on the instance.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyTicker extends PIXI.Ticker {
+  myCustomMethod() { ... }
+}
+
+const ticker = new MyTicker()
+<Ticker instance={ticker} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49).
+When using the base `PIXI.Ticker` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/docs/src/content/docs/api/components/tiling-sprite.mdx
+++ b/docs/src/content/docs/api/components/tiling-sprite.mdx
@@ -13,6 +13,27 @@ Renders a PIXI.TilingSprite.
   source="https://pixijs.download/dev/docs/scene.TilingSprite.html"
 />
 
+## Type-Safety Limitation with Subclasses
+
+:::caution[Important: Using Subclasses]
+If you are extending `PIXI.TilingSprite` with your own subclass, you **MUST** provide the `instance` prop with your custom instance.
+
+Due to TypeScript's limitations with generic types, if you don't provide an instance, a base `PIXI.TilingSprite` will be created and unsafely cast to your subclass type. This will cause **runtime errors** when trying to access subclass-specific properties or methods.
+
+**Correct Usage with Subclasses:**
+
+```typescript
+class MyTilingSprite extends PIXI.TilingSprite {
+  myCustomMethod() { ... }
+}
+
+const sprite = new MyTilingSprite()
+<TilingSprite instance={sprite} />
+```
+
+This limitation is documented in [issue #49](https://github.com/mattjennings/svelte-pixi/issues/49). When using the base `PIXI.TilingSprite` type (the default), this is not a concern.
+:::
+
 ## Usage
 
 <SvelteTabs>

--- a/src/lib/svelte-4/AnimatedSprite.svelte
+++ b/src/lib/svelte-4/AnimatedSprite.svelte
@@ -75,6 +75,24 @@
   /**
    * The PIXI.AnimatedSprite instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.AnimatedSprite,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.AnimatedSprite will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyAnimatedSprite extends PIXI.AnimatedSprite {
+   *   myMethod() { ... }
+   * }
+   * const sprite = new MyAnimatedSprite(textures)
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <AnimatedSprite instance={sprite} />
+   * ```
+   *
    * @type {PIXI.AnimatedSprite}
    */
   export let instance: T = new PIXI.AnimatedSprite({

--- a/src/lib/svelte-4/Application.svelte
+++ b/src/lib/svelte-4/Application.svelte
@@ -275,9 +275,27 @@
   export let width: $$Props['width'] = undefined
 
   /**
-   * The PIXI.Application instance. This can be manually set or bound to.
+   * The PIXI.Application instance. Can be manually set or bound to.
    *
    * Note: if manually set, props will not be applied.
+   *
+   * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Application,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.Application will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyApp extends PIXI.Application {
+   *   myMethod() { ... }
+   * }
+   * const app = new MyApp()
+   *
+   * <!-- Correct: always provide instance for subclasses. -->
+   * <Application instance={app} />
+   * ```
    *
    * @type {PIXI.Application}
    */

--- a/src/lib/svelte-4/BitmapText.svelte
+++ b/src/lib/svelte-4/BitmapText.svelte
@@ -48,6 +48,24 @@
   /**
    * The PIXI.BitmapText instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.BitmapText,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.BitmapText will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyBitmapText extends PIXI.BitmapText {
+   *   myMethod() { ... }
+   * }
+   * const bitmapText = new MyBitmapText()
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <BitmapText instance={bitmapText} />
+   * ```
+   *
    * @type {PIXI.BitmapText}
    */
   export let instance: T = new PIXI.BitmapText({

--- a/src/lib/svelte-4/Container.svelte
+++ b/src/lib/svelte-4/Container.svelte
@@ -390,7 +390,25 @@
   export let isRenderGroup: $$Props['isRenderGroup'] = false
 
   /**
-   * The PIXI.Container instance. Can be set or bound to.
+   * The PIXI.Container instance. Can be manually set or bound to.
+   *
+   * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Container,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.Container will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyContainer extends PIXI.Container {
+   *   myMethod() { ... }
+   * }
+   * const container = new MyContainer()
+   *
+   * <!-- Correct: always provide instance for subclasses. -->
+   * <Container instance={container} />
+   * ```
    *
    * @type {PIXI.Container}
    */

--- a/src/lib/svelte-4/Graphics.svelte
+++ b/src/lib/svelte-4/Graphics.svelte
@@ -42,6 +42,24 @@
   /**
    * The PIXI.Graphics instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.Graphics,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.Graphics will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyGraphics extends PIXI.Graphics {
+   *   myMethod() { ... }
+   * }
+   * const graphics = new MyGraphics()
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <Graphics instance={graphics} />
+   * ```
+   *
    * @type {PIXI.Graphics}
    */
   export let instance: T = new PIXI.Graphics({

--- a/src/lib/svelte-4/HTMLText.svelte
+++ b/src/lib/svelte-4/HTMLText.svelte
@@ -56,7 +56,25 @@
   export let roundPixels: $$Props['roundPixels'] = undefined
 
   /**
-   * The PIXI.Text instance. Can be set or bound to.
+   * The PIXI.HTMLText instance. Can be set or bound to.
+   *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.HTMLText,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.HTMLText will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyHTMLText extends PIXI.HTMLText {
+   *   myMethod() { ... }
+   * }
+   * const htmlText = new MyHTMLText()
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <HTMLText instance={htmlText} />
+   * ```
    *
    * @type {PIXI.HTMLText}
    */

--- a/src/lib/svelte-4/Mesh.svelte
+++ b/src/lib/svelte-4/Mesh.svelte
@@ -44,6 +44,24 @@
   /**
    * The PIXI.Mesh instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.Mesh,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.Mesh will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyMesh extends PIXI.Mesh {
+   *   myMethod() { ... }
+   * }
+   * const mesh = new MyMesh(geometry, shader)
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <Mesh instance={mesh} />
+   * ```
+   *
    * @type {PIXI.Mesh}
    */
   export let instance: T = new PIXI.Mesh({

--- a/src/lib/svelte-4/MeshPlane.svelte
+++ b/src/lib/svelte-4/MeshPlane.svelte
@@ -52,6 +52,24 @@
   /**
    * The PIXI.MeshPlane instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.MeshPlane,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.MeshPlane will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyMeshPlane extends PIXI.MeshPlane {
+   *   myMethod() { ... }
+   * }
+   * const plane = new MyMeshPlane(texture)
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <MeshPlane instance={plane} />
+   * ```
+   *
    * @type {PIXI.MeshPlane}
    */
   export let instance: T = new PIXI.MeshPlane({

--- a/src/lib/svelte-4/MeshRope.svelte
+++ b/src/lib/svelte-4/MeshRope.svelte
@@ -73,6 +73,24 @@
   /**
    * The PIXI.MeshRope instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.MeshRope,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.MeshRope will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyMeshRope extends PIXI.MeshRope {
+   *   myMethod() { ... }
+   * }
+   * const rope = new MyMeshRope(texture, points)
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <MeshRope instance={rope} />
+   * ```
+   *
    * @type {PIXI.MeshRope}
    */
   export let instance: T = new PIXI.MeshRope({

--- a/src/lib/svelte-4/NineSliceSprite.svelte
+++ b/src/lib/svelte-4/NineSliceSprite.svelte
@@ -71,6 +71,24 @@
   /**
    * The PIXI.NineSliceSprite instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.NineSliceSprite,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.NineSliceSprite will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyNineSliceSprite extends PIXI.NineSliceSprite {
+   *   myMethod() { ... }
+   * }
+   * const sprite = new MyNineSliceSprite(texture)
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <NineSliceSprite instance={sprite} />
+   * ```
+   *
    * @type {PIXI.NineSliceSprite}
    */
   export let instance: T = new PIXI.NineSliceSprite({

--- a/src/lib/svelte-4/ParticleContainer.svelte
+++ b/src/lib/svelte-4/ParticleContainer.svelte
@@ -40,6 +40,24 @@
   /**
    * The PIXI.ParticleContainer instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.ParticleContainer,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.ParticleContainer will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyParticleContainer extends PIXI.ParticleContainer {
+   *   myMethod() { ... }
+   * }
+   * const container = new MyParticleContainer()
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <ParticleContainer instance={container} />
+   * ```
+   *
    * @type {PIXI.ParticleContainer}
    */
   export let instance: T = new PIXI.ParticleContainer({

--- a/src/lib/svelte-4/PerspectiveMesh.svelte
+++ b/src/lib/svelte-4/PerspectiveMesh.svelte
@@ -100,6 +100,24 @@
   /**
    * The PIXI.PerspectiveMesh instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.PerspectiveMesh,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.PerspectiveMesh will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyPerspectiveMesh extends PIXI.PerspectiveMesh {
+   *   myMethod() { ... }
+   * }
+   * const mesh = new MyPerspectiveMesh(texture)
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <PerspectiveMesh instance={mesh} />
+   * ```
+   *
    * @type {PIXI.PerspectiveMesh}
    */
   export let instance: T = new PIXI.PerspectiveMesh({

--- a/src/lib/svelte-4/Renderer.svelte
+++ b/src/lib/svelte-4/Renderer.svelte
@@ -196,8 +196,27 @@
   export let skipExtensionImports: $$Props['skipExtensionImports'] = undefined
 
   /**
-   * The PIXI.Renderer instance. Can be set or bound to. By default
-   * it uses PIXI.autoDetectRenderer()
+   * The PIXI.Renderer instance. Can be manually set or bound to.
+   *
+   * By default it uses `PIXI.autoDetectRenderer()`.
+   *
+   * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Renderer,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance and rely on
+   * `autoDetectRenderer()`, the result will be cast to your type, which will cause
+   * runtime errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyRenderer extends PIXI.Renderer {
+   *   myMethod() { ... }
+   * }
+   * const renderer = new MyRenderer()
+   *
+   * <!-- Correct: always provide instance for subclasses. -->
+   * <Renderer instance={renderer} />
+   * ```
    */
   export let instance: T | undefined = undefined
 

--- a/src/lib/svelte-4/Sprite.svelte
+++ b/src/lib/svelte-4/Sprite.svelte
@@ -50,6 +50,24 @@
   /**
    * The PIXI.Sprite instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.Sprite,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.Sprite will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MySprite extends PIXI.Sprite {
+   *   myMethod() { ... }
+   * }
+   * const sprite = new MySprite()
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <Sprite instance={sprite} />
+   * ```
+   *
    * @type {PIXI.Sprite}
    */
   export let instance: T = new PIXI.Sprite({

--- a/src/lib/svelte-4/Text.svelte
+++ b/src/lib/svelte-4/Text.svelte
@@ -60,6 +60,24 @@
   /**
    * The PIXI.Text instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.Text,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.Text will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyText extends PIXI.Text {
+   *   myMethod() { ... }
+   * }
+   * const text = new MyText()
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <Text instance={text} />
+   * ```
+   *
    * @type {PIXI.Text}
    */
   export let instance: T = new PIXI.Text({ text, style }) as T

--- a/src/lib/svelte-4/Ticker.svelte
+++ b/src/lib/svelte-4/Ticker.svelte
@@ -43,7 +43,25 @@
   export let speed: $$Props['speed'] = undefined
 
   /**
-   * The PIXI.Ticker instance. Can be set or bound to.
+   * The PIXI.Ticker instance. Can be manually set or bound to.
+   *
+   * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Ticker,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.Ticker will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyTicker extends PIXI.Ticker {
+   *   myMethod() { ... }
+   * }
+   * const ticker = new MyTicker()
+   *
+   * <!-- Correct: always provide instance for subclasses. -->
+   * <Ticker instance={ticker} />
+   * ```
    *
    * @type {PIXI.Ticker}
    */

--- a/src/lib/svelte-4/TilingSprite.svelte
+++ b/src/lib/svelte-4/TilingSprite.svelte
@@ -100,6 +100,24 @@
   /**
    * The PIXI.TilingSprite instance. Can be set or bound to.
    *
+   * WARNING: Type-safety limitation - If you are using a subclass of PIXI.TilingSprite,
+   * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+   * limitations with generic types, if you don't provide an instance, a base
+   * PIXI.TilingSprite will be created and cast to your type, which will cause runtime
+   * errors when trying to access subclass-specific properties or methods.
+   *
+   * Example:
+   *
+   * ```typescript
+   * class MyTilingSprite extends PIXI.TilingSprite {
+   *   myMethod() { ... }
+   * }
+   * const sprite = new MyTilingSprite()
+   *
+   * <!-- Correct: always provide instance for subclasses -->
+   * <TilingSprite instance={sprite} />
+   * ```
+   *
    * @type {PIXI.TilingSprite}
    */
   export let instance: T = new PIXI.TilingSprite({

--- a/src/lib/svelte-5/AnimatedSprite.svelte
+++ b/src/lib/svelte-5/AnimatedSprite.svelte
@@ -18,6 +18,26 @@
         | 'onLoop',
         'textures'
       > {
+    /**
+     * The PIXI.AnimatedSprite instance. Can be set or bound to.
+     *
+     * WARNING: Type-safety limitation - If you are using a subclass of PIXI.AnimatedSprite,
+     * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+     * limitations with generic types, if you don't provide an instance, a base
+     * PIXI.AnimatedSprite will be created and cast to your type, which will cause runtime
+     * errors when trying to access subclass-specific properties or methods.
+     *
+     * Example:
+     * ```typescript
+     * class MyAnimatedSprite extends PIXI.AnimatedSprite {
+     *   myMethod() { ... }
+     * }
+     * const sprite = new MyAnimatedSprite(textures)
+     *
+     * <!-- Correct: always provide instance for subclasses -->
+     * <AnimatedSprite instance={sprite} />
+     * ```
+     */
     instance?: T
 
     // because pixi has camel casing on these handlers, we'll also

--- a/src/lib/svelte-5/Application.svelte
+++ b/src/lib/svelte-5/Application.svelte
@@ -4,10 +4,28 @@
     T extends PIXI.Application = PIXI.Application,
   > extends Partial<Omit<PIXI.ApplicationOptions, 'view'>> {
     /**
-     * The PIXI.Application instance. This can be manually set or bound to.
+     * The PIXI.Application instance. Can be manually set or bound to.
      *
      * Note: if manually set any PIXI.ApplicationOptions props will not be set
      * as they are passed into the constructor
+     *
+     * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Application,
+     * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+     * limitations with generic types, if you don't provide an instance, a base
+     * PIXI.Application will be created and cast to your type, which will cause runtime
+     * errors when trying to access subclass-specific properties or methods.
+     *
+     * Example:
+     *
+     * ```typescript
+     * class MyApp extends PIXI.Application {
+     *   myMethod() { ... }
+     * }
+     * const app = new MyApp()
+     *
+     * <!-- Correct: always provide instance for subclasses. -->
+     * <Application instance={app} />
+     * ```
      *
      * @type {PIXI.Application}
      */

--- a/src/lib/svelte-5/BitmapText.svelte
+++ b/src/lib/svelte-5/BitmapText.svelte
@@ -6,6 +6,26 @@
         PIXI.BitmapText,
         'anchor' | 'roundPixels' | 'text' | 'style'
       > {
+    /**
+     * The PIXI.BitmapText instance. Can be set or bound to.
+     *
+     * WARNING: Type-safety limitation - If you are using a subclass of PIXI.BitmapText,
+     * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+     * limitations with generic types, if you don't provide an instance, a base
+     * PIXI.BitmapText will be created and cast to your type, which will cause runtime
+     * errors when trying to access subclass-specific properties or methods.
+     *
+     * Example:
+     * ```typescript
+     * class MyBitmapText extends PIXI.BitmapText {
+     *   myMethod() { ... }
+     * }
+     * const bitmapText = new MyBitmapText()
+     *
+     * <!-- Correct: always provide instance for subclasses -->
+     * <BitmapText instance={bitmapText} />
+     * ```
+     */
     instance?: T
   }
 </script>

--- a/src/lib/svelte-5/Container.svelte
+++ b/src/lib/svelte-5/Container.svelte
@@ -74,6 +74,27 @@
     | 'ontouchmove'
     | 'ontouchstart'
   > {
+    /**
+     * The PIXI.Container instance. Can be manually set or bound to.
+     *
+     * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Container,
+     * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+     * limitations with generic types, if you don't provide an instance, a base
+     * PIXI.Container will be created and cast to your type, which will cause runtime
+     * errors when trying to access subclass-specific properties or methods.
+     *
+     * Example:
+     *
+     * ```typescript
+     * class MyContainer extends PIXI.Container {
+     *   myMethod() { ... }
+     * }
+     * const container = new MyContainer()
+     *
+     * <!-- Correct: always provide instance for subclasses. -->
+     * <Container instance={container} />
+     * ```
+     */
     instance?: T
 
     /**

--- a/src/lib/svelte-5/Graphics.svelte
+++ b/src/lib/svelte-5/Graphics.svelte
@@ -3,6 +3,26 @@
     extends
       ContainerProps<T>,
       PickPixiProps<PIXI.Graphics, 'blendMode' | 'tint'> {
+    /**
+     * The PIXI.Graphics instance. Can be set or bound to.
+     *
+     * WARNING: Type-safety limitation - If you are using a subclass of PIXI.Graphics,
+     * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+     * limitations with generic types, if you don't provide an instance, a base
+     * PIXI.Graphics will be created and cast to your type, which will cause runtime
+     * errors when trying to access subclass-specific properties or methods.
+     *
+     * Example:
+     * ```typescript
+     * class MyGraphics extends PIXI.Graphics {
+     *   myMethod() { ... }
+     * }
+     * const graphics = new MyGraphics()
+     *
+     * <!-- Correct: always provide instance for subclasses -->
+     * <Graphics instance={graphics} />
+     * ```
+     */
     instance?: T
 
     /**

--- a/src/lib/svelte-5/Renderer.svelte
+++ b/src/lib/svelte-5/Renderer.svelte
@@ -3,8 +3,27 @@
     T extends PIXI.Renderer = PIXI.Renderer,
   > extends Partial<Omit<PIXI.AutoDetectOptions, 'view'>> {
     /**
-     * The PIXI.Renderer instance. Can be set or bound to. By default
-     * PIXI.autoDetectRenderer() is called and sets the instance when it resolves
+     * The PIXI.Renderer instance. Can be set or bound to.
+     *
+     * By default `PIXI.autoDetectRenderer()` is called and sets the instance when it resolves.
+     *
+     * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Renderer,
+     * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+     * limitations with generic types, if you don't provide an instance and rely on
+     * autoDetectRenderer(), the result will be cast to your type, which will cause
+     * runtime errors when trying to access subclass-specific properties or methods.
+     *
+     * Example:
+     *
+     * ```typescript
+     * class MyRenderer extends PIXI.Renderer {
+     *   myMethod() { ... }
+     * }
+     * const renderer = new MyRenderer()
+     *
+     * <!-- Correct: always provide instance for subclasses. -->
+     * <Renderer instance={renderer} />
+     * ```
      */
     instance?: T
 

--- a/src/lib/svelte-5/Ticker.svelte
+++ b/src/lib/svelte-5/Ticker.svelte
@@ -5,6 +5,27 @@
     PIXI.Ticker,
     'autoStart' | 'maxFPS' | 'minFPS' | 'speed'
   > {
+    /**
+     * The PIXI.Ticker instance. Can be manually set or bound to.
+     *
+     * WARNING: Type-safety limitation: If you are using a subclass of PIXI.Ticker,
+     * you MUST provide the instance prop with your custom instance. Due to TypeScript's
+     * limitations with generic types, if you don't provide an instance, a base
+     * PIXI.Ticker will be created and cast to your type, which will cause runtime
+     * errors when trying to access subclass-specific properties or methods.
+     *
+     * Example:
+     *
+     * ```typescript
+     * class MyTicker extends PIXI.Ticker {
+     *   myMethod() { ... }
+     * }
+     * const ticker = new MyTicker()
+     *
+     * <!-- Correct: always provide instance for subclasses. -->
+     * <Ticker instance={ticker} />
+     * ```
+     */
     instance?: T
 
     /**


### PR DESCRIPTION
Resolves https://github.com/mattjennings/svelte-pixi/issues/49 by adding extending documentation with warning.